### PR TITLE
removed matplotlib from make_density_map

### DIFF
--- a/make_density_map.py
+++ b/make_density_map.py
@@ -4,7 +4,6 @@
 Scripts for determining centroid density maps and segmentation masks as targetes for CNN.  See docstrings of functions for further help.
 """
 
-import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
 from PIL import Image


### PR DESCRIPTION
Keeping matplotlib screws up the code on p8t0X, and it doesnt do anything. 